### PR TITLE
build: remove cmake dependency file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
           mkdir -p "$HOME/.sonar"
           curl -sSLo "$HOME/.sonar/sonar-scanner.zip" "${{ env.SONAR_SCANNER_DOWNLOAD_URL }}"
           unzip -o "$HOME/.sonar/sonar-scanner.zip" -d "$HOME/.sonar/"
+          sed -i 's/use_embedded_jre=true/use_embedded_jre=false/' "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin/sonar-scanner"
           echo "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> "$GITHUB_PATH"
 
       - name: Download and set up build-wrapper

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,7 @@ sonar.sourceEncoding=UTF-8
 sonar.language=c++
 
 # Use this if you have a specific build tool (optional)
-sonar.cfamily.build-wrapper-output=build/build_wrapper_directory
+sonar.cfamily.build-wrapper-output=build_wrapper_output_directory
 
 # If you're using GCC or Clang, provide the path to the compilation database (optional)
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
Remove the auto-generated CMake dependency file from version
control. This file contains machine-specific paths and is
regenerated during each build, making it unsuitable for
tracking in the repository.