### PR TITLE
ci: upgrade sonar scanner and fix wrapper path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
     permissions:
       contents: read
     env:
-      SONAR_SCANNER_VERSION: 4.6.1.2450
+      SONAR_SCANNER_VERSION: 8.0.1.6346
       SONAR_SERVER_URL: "https://sonarcloud.io"
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+      BUILD_WRAPPER_OUT_DIR: build/wrapper_output_directory
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Upgrade SonarQube scanner from version 4.6.1.2450 to 8.0.1.6346
to leverage latest improvements and security updates. Update the
build wrapper output directory path from
build_wrapper_output_directory to build/wrapper_output_directory
to align with project structure conventions.