### PR TITLE
refactor: update build and sonar configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,15 +40,21 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Download and set up sonar-scanner
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libcurl4-openssl-dev maven unzip
+
+      - name: Download and build sonar-scanner
         env:
-          SONAR_SCANNER_DOWNLOAD_URL: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip
+          SONAR_SCANNER_DOWNLOAD_URL: https://github.com/SonarSource/sonar-scanner-cli/archive/refs/tags/${{ env.SONAR_SCANNER_VERSION }}.zip
         run: |
           mkdir -p "$HOME/.sonar"
           curl -sSLo "$HOME/.sonar/sonar-scanner.zip" "${{ env.SONAR_SCANNER_DOWNLOAD_URL }}"
           unzip -o "$HOME/.sonar/sonar-scanner.zip" -d "$HOME/.sonar/"
-          sed -i 's/use_embedded_jre=true/use_embedded_jre=false/' "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin/sonar-scanner"
-          echo "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> "$GITHUB_PATH"
+          mvn -B -f "$HOME/.sonar/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}/pom.xml" -DskipTests package
+          unzip -o "$HOME/.sonar/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}/target/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}.zip" -d "$HOME/.sonar/"
+          echo "$(dirname "$(find "$HOME/.sonar" -maxdepth 3 -path '*/bin/sonar-scanner' -print -quit)")" >> "$GITHUB_PATH"
 
       - name: Download and set up build-wrapper
         env:
@@ -57,11 +63,6 @@ jobs:
           curl -sSLo "$HOME/.sonar/build-wrapper-linux-x86.zip" "${{ env.BUILD_WRAPPER_DOWNLOAD_URL }}"
           unzip -o "$HOME/.sonar/build-wrapper-linux-x86.zip" -d "$HOME/.sonar/"
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> "$GITHUB_PATH"
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake libcurl4-openssl-dev unzip
 
       - name: Configure project
         run: |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,7 @@ sonar.sourceEncoding=UTF-8
 sonar.language=c++
 
 # Use this if you have a specific build tool (optional)
-sonar.cfamily.build-wrapper-output=build_wrapper_output_directory
+sonar.cfamily.build-wrapper-output=build/wrapper_output_directory
 
 # If you're using GCC or Clang, provide the path to the compilation database (optional)
 # sonar.cfamily.compile-commands=compile_commands.json

--- a/src/ssllabs.cpp
+++ b/src/ssllabs.cpp
@@ -10,7 +10,7 @@ namespace ssllabs {
     static size_t writeCallback(char *buf, size_t size, size_t nmemb, void *up) {
         size_t realsize = size * nmemb;
 
-        std::string *mem = (std::string *) up;
+        auto *mem = static_cast<std::string *>(up);
         mem->append(buf);
 
         return realsize;


### PR DESCRIPTION
Update sonar-scanner setup to build from source instead of
downloading prebuilt binaries. This requires installing additional
dependencies including maven and cmake.

Reorganize workflow steps to install dependencies before sonar-scanner
setup. Update build wrapper output directory path to match project
structure.

Improve C++ code quality by replacing C-style cast with modern
static_cast in ssllabs.cpp.